### PR TITLE
Fix exception in PostActivity

### DIFF
--- a/ActivityWeatherSchedulerBlazor.Client/Pages/Index.cshtml
+++ b/ActivityWeatherSchedulerBlazor.Client/Pages/Index.cshtml
@@ -263,7 +263,7 @@ protected async Task PostActivity()
 			Above = Above
 		};
 
-		await Http.PostJsonAsync<Activity>($"api/WeatherForecast/AddActivity", activity);
+		await Http.PostJsonAsync($"api/WeatherForecast/AddActivity", activity);
 		await GetActivities();
 	}
 }


### PR DESCRIPTION
Remove type parameter as HTTP POST does not return a JSON response. The type parameter leads to an exception because Blazor is trying to deserialize an `Activity` from an empty response. After removing the type parameter, `PostActivity` does refresh the list of activities.